### PR TITLE
Fix critical error that prevents Tracker startup for BW/BW2

### DIFF
--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -257,7 +257,7 @@ local function Program(initialTracker, initialMemoryAddresses, initialGameInfo, 
 
 	function self.addAdditionalDataToPokemon(pokemon)
 		local constData = PokemonData.POKEMON[pokemon.pokemonID + 1]
-		for key, data in pairs(constData) do
+		for key, data in pairs(constData or {}) do
 			--when tracker makes a template it does the name because alternate forms are complex, so don't overwrite it
 			if key == "name" then
 				if not pokemon.name then

--- a/ironmon_tracker/SeedLogger.lua
+++ b/ironmon_tracker/SeedLogger.lua
@@ -164,10 +164,10 @@ local function SeedLogger(initialProgram, initialGameName)
             SPD = pokemon.SPD,
             SPE = pokemon.SPE
         }
-        program.addAdditionalDataToPokemon(pokemon)
         if not MiscUtils.validPokemonData(pokemon) then
             return nil
         end
+		program.addAdditionalDataToPokemon(pokemon)
         return pokemon
     end
 

--- a/ironmon_tracker/utils/DrawingUtils.lua
+++ b/ironmon_tracker/utils/DrawingUtils.lua
@@ -496,8 +496,7 @@ function DrawingUtils.drawExtraMainScreenStuff(extraThingsToDraw)
             extraThingsToDraw.experienceBar.y,
             extraThingsToDraw.experienceBar.percent
         DrawingUtils.drawExperienceBar(x, y, percent)
-    end
-    if extraThingsToDraw.friendshipBar ~= nil then
+	elseif extraThingsToDraw.friendshipBar ~= nil then
         local x, y, progress =
             extraThingsToDraw.friendshipBar.x,
             extraThingsToDraw.friendshipBar.y,


### PR DESCRIPTION
This PR fixes two separate issues.

- The first is an issue that is reportedly frequently in the Ironmon Discord; it affects many players on a daily basis.
- The second is a simple UI tweak to fix overlapping components.

## 1. Critical error that crashes the Tracker script on-startup
Under some rare cases, the `.pastlog` file for BW/BW2 games can become corrupted to some degree, containing bad data about a Pokémon. This results in the SeedLogger failing to properly load this Pokémon data. Here is the reported Lua Console exception:

```text
NLua.Exceptions.LuaScriptException:
ironmon_tracker/Program.lua:260: bad argument #1 to 'for iterator' (table expected, got nil)"
```

This seems to occur more frequently after a deep run. My guess as to why this occurs is something to do with saving/parsing info for alternate forme Pokémon. I don't have a test log to verify.

**To Fix:** I adjusted two lines of code as safety measures to prevent this crash. First I added an `or {}` at the exact line of code where the crash occurred, to prevent the possibility of ever trying to iterate on a `nil` table. Second, I moved the `addAdditionalDataToPokemon()` function call to *after* the verification check on if the Pokémon data is valid.

## 2. FRIEND/READY evo text appears on top of the EXP Bar
The "FRIEND" or "READY" evo text is drawn separately from the UI component. Thus, the conditions for *when* to display this UI component don't seem to apply to this independent draw where it displays the FRIEND letters filling up over time to show friendship progress.

**To Fix:** I simply added a condition for when its okay to draw these extra FRIEND letters (the ones showing your progress towards max friendship) by also checking if the EXP bar is being drawn or not. Thus, if the EXP is being drawn, then don't draw the FRIEND letters. 

Before Fix
![image](https://github.com/Brian0255/NDS-Ironmon-Tracker/assets/4258818/a040931a-6c30-4ad8-871d-f5fe7162fa98)

After Fix
![image](https://github.com/Brian0255/NDS-Ironmon-Tracker/assets/4258818/098e2cd9-5211-43c2-8dfb-4e6334f909fc)
