### PR TITLE
Fix playtime file corruption if not-a-number

### DIFF
--- a/ironmon_tracker/Tracker.lua
+++ b/ironmon_tracker/Tracker.lua
@@ -68,10 +68,10 @@ local function Tracker()
 
 	function self.loadTotalPlaytime(gameName)
 		local playtimeFile = "savedData/" .. gameName .. ".pt"
-		local seconds = MiscUtils.readStringFromFile(playtimeFile)
-		if seconds ~= nil then
+		local seconds = tonumber(MiscUtils.readStringFromFile(playtimeFile) or "", 10)
+		if type(seconds) == "number" then
 			totalSeconds = seconds
-			startSeconds = tonumber(seconds, 10)
+			startSeconds = seconds
 		end
 	end
 
@@ -82,7 +82,8 @@ local function Tracker()
 
 	function self.updatePlaytime(gameName)
 		local playtimeFile = "savedData/" .. gameName .. ".pt"
-		totalSeconds = startSeconds + (os.time() - sessionStartTime)
+		local additionalTime = math.max(os.time() - sessionStartTime, 0)
+		totalSeconds = startSeconds + additionalTime
 		MiscUtils.writeStringToFile(playtimeFile, tostring(totalSeconds))
 	end
 


### PR DESCRIPTION
Fixes the following error, which will permanently crash the Tracker on-startup. This fix ensures only real numbers are set to the time tracking variables used for playtime calculations.

NLua.Exceptions.LuaScriptException: ironmon_tracker/Tracker.lua:85: attempt to perform arithmetic on upvalue 'startSeconds' (a nil value)