### PR TITLE
Poison overlay bugfix

### DIFF
--- a/ironmon_tracker/ui/MainScreen.lua
+++ b/ironmon_tracker/ui/MainScreen.lua
@@ -379,7 +379,7 @@ local function MainScreen(initialSettings, initialTracker, initialProgram)
         if program.getGameInfo().GEN == 4 then
             local statusTable = {
                 [0] = "",
-			     [8] = "PSN",
+				[8] = "PSN",
                 [16] = "BRN",
                 [32] = "FRZ",
                 [64] = "PAR",

--- a/ironmon_tracker/ui/MainScreen.lua
+++ b/ironmon_tracker/ui/MainScreen.lua
@@ -379,6 +379,7 @@ local function MainScreen(initialSettings, initialTracker, initialProgram)
         if program.getGameInfo().GEN == 4 then
             local statusTable = {
                 [0] = "",
+			     [8] = "PSN",
                 [16] = "BRN",
                 [32] = "FRZ",
                 [64] = "PAR",


### PR DESCRIPTION
At some point, regular poison code got removed in this table, so regular poison in Gen 4 was not triggering the overlay.

Apologies once again for spacing, my VS Code never likes the NDS codebase