### PR TITLE
Basic auto ability note tracking for Gen4 games

### DIFF
--- a/ironmon_tracker/GameConfigurator.lua
+++ b/ironmon_tracker/GameConfigurator.lua
@@ -96,7 +96,7 @@ function GameConfigurator.initAbilityData(gameInfo)
 	local versionDifferenceIndex = gameInfo.GEN - 3
 	for index, info in pairs(AbilityData.ABILITIES_MASTER_LIST) do
 		if gameInfo.GEN == 4 and index == 125 then
-			return
+			break
 		end
 		AbilityData.ABILITIES[index] = {}
 		for key, value in pairs(info) do
@@ -105,6 +105,20 @@ function GameConfigurator.initAbilityData(gameInfo)
 			else
 				AbilityData.ABILITIES[index][key] = value
 			end
+		end
+	end
+
+	AbilityData.BATTLE_MSGS = {}
+	local battleMsgsToCopy
+	if gameInfo.GEN == 4 then
+		battleMsgsToCopy = AbilityData.BATTLE_MSGS_MASTER_LIST.GEN4
+	elseif gameInfo.GEN == 5 then
+		battleMsgsToCopy = AbilityData.BATTLE_MSGS_MASTER_LIST.GEN5
+	end
+	for msgId, abilityIdList in pairs(battleMsgsToCopy or {}) do
+		AbilityData.BATTLE_MSGS[msgId] = {}
+		for _, abilityId in pairs(abilityIdList) do
+			AbilityData.BATTLE_MSGS[msgId][abilityId] = true
 		end
 	end
 end

--- a/ironmon_tracker/constants/AbilityData.lua
+++ b/ironmon_tracker/constants/AbilityData.lua
@@ -1,6 +1,7 @@
 AbilityData = {}
 
 AbilityData.ABILITIES = {}
+AbilityData.BATTLE_MSGS = {}
 
 AbilityData.ABILITIES_MASTER_LIST = {
     {
@@ -873,4 +874,56 @@ AbilityData.ABILITIES_MASTER_LIST = {
         name = "Teravolt",
         description = "Bypasses targets' abilities if they could hinder or prevent moves."
     }
+}
+
+-- Map a battle message id (key) to a list of ability id's (value) that could trigger it
+AbilityData.BATTLE_MSGS_MASTER_LIST = {
+	-- List: https://github.com/pret/pokeheartgold/blob/448bea8e0692a2affab92739e73e80d9636b7aa0/include/constants/battle_subscript.h
+	GEN4 = {
+		[ 12]  = { 3, 88, }, -- 3:Speed Boost, 88:Download -- TODO: Speedboost requires testing (download works)
+		--[ 16]  = { 83 }, -- 83:Anger Point, -- TODO: technically works but might false trigger, removing for now
+		[ 22]  = { 38, 27, }, -- 38:Poison Point, 27:Effect Spore
+		[ 18]  = { 27, }, -- 27:Effect Spore
+		[ 25]  = { 49, }, -- 49:Flame Body
+		[ 31]  = { 9, 27, }, -- 9:Static, 27:Effect Spore
+		[106]  = { 56, }, -- 56:Cute Charm
+		[177]  = { 104, }, -- 104:Mold Breaker
+		[178]  = { 10, 11, 87, }, -- 10:Volt Absorb, 11:Water Absorb, 87:Dry Skin
+		[179]  = { 18, }, -- 18:Flash Fire
+		[180]  = { 31, 114, }, -- 31:Lightningrod, 114:Storm Drain
+		[181]  = { 43, }, -- 43:Soundproof
+		[182]  = { 78, }, -- 78:Motor Drive
+		[183]  = { 2, }, -- 2:Drizzle
+		[184]  = { 45, }, -- 45:Sand Stream
+		[185]  = { 70, }, -- 70:Drought
+		[186]  = { 22, }, -- 22:Intimidate
+		[187]  = { 36, }, -- 36:Trace
+		[188]  = { 16, }, -- 16:Color Change
+		[189]  = { 24, }, -- 24:Rough Skin
+		[190]  = { 61, }, -- 61:Shed Skin
+		[191]  = { 54, }, -- 54:Truant
+		[192]  = { 44, 87 }, -- 44:Rain Dish, 87:Dry Skin
+		[193]  = { 106, }, -- 106:Aftermath
+		[194]  = { 107, }, -- 107:Anticipation
+		[195]  = { 108, }, -- 108:Forewarn
+		[196]  = { 112, }, -- 112:Slow Start
+		-- 7:Limber, 12:Oblivious, 15:Insomnia, 17:Immunity, 20:Own Tempo, 40:Magma Armor, 41:Water Veil, 72:Vital Spirit,
+		[221]  = { 7, 12, 15, 17, 20, 40, 41, 72, },
+		[252]  = { 117, }, -- 117:Snow Warning
+		[253]  = { 119, }, -- 119:Frisk
+		[285]  = { 46, }, -- 46:Pressure
+	},
+	--[[ Ability master list to test for Gen 4
+		Static, flame body, pressure, mold breaker, frisk, forewarn, anticipation, anger point,
+		poison point, effect spore, insomnia, flash fire, levitate, volt absorb, motor drive,
+		water absorb, intimidate, download, hyper cutter, clear body, speed boost, own tempo,
+		sturdy, drought, drizzle, snow warning, sand stream, immunity, steadfast, inner focus,
+		oblivious, cute charm, aftermath, rough skin, damp, color change, suction cups, wonder guard,
+		trace, water veil, soundproof, rain dish, keen eye, truant, slow start, shed skin, poison heal,
+		hydration, solar power, ice body, bad dreams, and magic guard
+
+		Other notes:
+		Dry Skin doesnt work with rain, Syncrhonize seems tough to trigger on (be careful)
+		-Clear body, white smoke, keen eye, hyper cutter all use 2 messages
+	]]
 }

--- a/ironmon_tracker/constants/MemoryAddresses.lua
+++ b/ironmon_tracker/constants/MemoryAddresses.lua
@@ -44,7 +44,8 @@ MemoryAddresses[GameInfo.VERSION_NUMBER.HEART_GOLD] = {
         kantoBadges = 0x93,
         leagueBeaten = 0x1000,
         facingDirection = 0x25DA8,
-        repelSteps = 0x6919
+        repelSteps = 0x6919,
+        battleSubscriptMsgs = 0x47184
     },
     GLOBAL = {
         battleStatus = 0x246F48
@@ -74,7 +75,8 @@ MemoryAddresses[GameInfo.VERSION_NUMBER.SOUL_SILVER] = {
         kantoBadges = 0x93,
         leagueBeaten = 0x1000,
         facingDirection = 0x25DA8,
-        repelSteps = 0x6919
+        repelSteps = 0x6919,
+        battleSubscriptMsgs = 0x47184
     },
     GLOBAL = {
         battleStatus = 0x246F48
@@ -102,7 +104,8 @@ MemoryAddresses[GameInfo.VERSION_NUMBER.PLATINUM] = {
         berryBagStartBattle = 0x4435C,
         badges = 0x96,
         facingDirection = 0x238A4,
-        repelSteps = 0x8087
+        repelSteps = 0x8087,
+        battleSubscriptMsgs = 0x44928
     },
     GLOBAL = {
         battleStatus = 0x24A55A
@@ -130,7 +133,8 @@ MemoryAddresses[GameInfo.VERSION_NUMBER.DIAMOND] = {
         berryBagStartBattle = 0x4550C,
         badges = 0x292,
         repelSteps = 0x764C,
-        facingDirection = 0x24A5C
+        facingDirection = 0x24A5C,
+        battleSubscriptMsgs = 0x458F0
     },
     GLOBAL = {
         battleStatus = 0x23BB38
@@ -158,7 +162,8 @@ MemoryAddresses[GameInfo.VERSION_NUMBER.PEARL] = {
         berryBagStartBattle = 0x4550C,
         badges = 0x292,
         repelSteps = 0x764C,
-        facingDirection = 0x24A5C
+        facingDirection = 0x24A5C,
+        battleSubscriptMsgs = 0x458F0
     },
     GLOBAL = {
         battleStatus = 0x23BB38


### PR DESCRIPTION
At long last, some auto ability note tracking! Tested to be compatible with HGSS and DPP.

### Description of Feature
What this does is watch the battle messages as they get displayed on the game screen during a battle. When a known ability message appears, this code checks who was the cause of that ability triggering, and tracks it accordingly. This tracks the ability internally in the Tracker data (TDAT), as well as writes a note for the Pokémon.

### Other Notes
- I currently only have about half the possible abilities being auto-tracked. Most of them have been tested already
- If both Pokémon have the same ability, there's no way, yet, to tell which one cause the ability to trigger. As such, nothing will be tracked for now.

![image](https://github.com/Brian0255/NDS-Ironmon-Tracker/assets/4258818/5620be63-6a9c-415b-b4ed-a588f01f36e6)
