### PR TITLE
Crash Recovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ Requests.json
 *.pt
 *.faves
 *.tdata
+*.State

--- a/ironmon_tracker/Main.lua
+++ b/ironmon_tracker/Main.lua
@@ -182,6 +182,7 @@ local function Main()
 		ThemeFactory.setSaveFunction(program.saveSettings)
 		ThemeFactory.setPokemonThemeDisablingFunction(program.turnOffPokemonTheme)
 		event.onexit(program.onProgramExit, "onProgramExit")
+		event.onconsoleclose(program.onExitAndCloseRequiredProcesses, "onExitAndCloseRequiredProcesses")
 		while not loadNextSeed do
 			program.main()
 			loadNextSeed = checkForNextSeedCombo()

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -40,6 +40,7 @@ local function Program(initialTracker, initialMemoryAddresses, initialGameInfo, 
 	local PokemonThemeManager = dofile(Paths.FOLDERS.DATA_FOLDER .. "/PokemonThemeManager.lua")
 	local TourneyTracker = dofile(Paths.FOLDERS.DATA_FOLDER .. "/TourneyTracker.lua")
 	dofile(Paths.FOLDERS.NETWORK_FOLDER .. "/Network.lua")
+	local CrashRecovery = dofile(Paths.FOLDERS.EXTRAS_FOLDER .. "/CrashRecovery.lua")
 
 	self.SELECTED_PLAYERS = {
 		PLAYER = 0,
@@ -83,6 +84,7 @@ local function Program(initialTracker, initialMemoryAddresses, initialGameInfo, 
 	local tourneyTracker
 	local pokemonThemeManager = PokemonThemeManager(settings, self)
 	local dayOfWeek = 2
+	local crashRecovery = CrashRecovery(settings)
 
 	local currentScreens = {}
 
@@ -621,6 +623,8 @@ local function Program(initialTracker, initialMemoryAddresses, initialGameInfo, 
 					self.addScreen(self.UI_SCREENS.TITLE_SCREEN)
 					currentScreens[self.UI_SCREENS.TITLE_SCREEN].setTopVisibility(false)
 				end
+				-- Once the game begins and the player is playing, starting automatically saving crash recovery backups
+				crashRecovery.startSavingBackups()
 			end
 		end
 		currentLocation = areaName
@@ -707,6 +711,7 @@ local function Program(initialTracker, initialMemoryAddresses, initialGameInfo, 
 	function self.tryToInstallUpdate(callbackFunc)
 		tracker.save(gameInfo.NAME)
 		Network.closeConnections()
+		crashRecovery.writeCrashReport()
 		local success = trackerUpdater.downloadUpdate()
 		if type(callbackFunc) == "function" then
 			callbackFunc(success)
@@ -1007,6 +1012,7 @@ local function Program(initialTracker, initialMemoryAddresses, initialGameInfo, 
 		animatedSprites = FrameCounter(8, advanceAnimationFrame, nil, true),
 		networkStartup = FrameCounter(30, delayedNetworkStartup, nil, true),
 		networkUpdate = FrameCounter(10, Network.update, nil, true),
+		crashRecovery = FrameCounter(crashRecovery.getBackupFrequency(), crashRecovery.createBackupSaveState, nil, true)
 	}
 
 	function self.pauseEventListeners()
@@ -1085,6 +1091,7 @@ local function Program(initialTracker, initialMemoryAddresses, initialGameInfo, 
 		client.saveram()
 		forms.destroyall()
 		Network.closeConnections()
+		crashRecovery.writeCrashReport()
 	end
 
 	function self.getSeedLogger()
@@ -1155,6 +1162,9 @@ local function Program(initialTracker, initialMemoryAddresses, initialGameInfo, 
 
 	Network.initialize()
 	Network.linkData(self, tracker, battleHandler)
+
+	crashRecovery.initialize()
+	crashRecovery.checkCrashStatus()
 
 	return self
 end

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -1085,12 +1085,19 @@ local function Program(initialTracker, initialMemoryAddresses, initialGameInfo, 
 		animateUpdate()
 	end
 
+	-- Closes down the Tracker, saves data, and shuts down any additional processes
 	function self.onProgramExit()
 		tracker.save(gameInfo.NAME)
 		tracker.updatePlaytime(gameInfo.NAME)
 		client.saveram()
 		forms.destroyall()
+		self.onExitAndCloseRequiredProcesses()
+	end
+	-- Only closes the most important, required processes
+	function self.onExitAndCloseRequiredProcesses()
+		-- Safely close any open connections
 		Network.closeConnections()
+		-- Write to the crash report file that a crash did *not* occur
 		crashRecovery.writeCrashReport()
 	end
 

--- a/ironmon_tracker/extras/CrashRecovery.lua
+++ b/ironmon_tracker/extras/CrashRecovery.lua
@@ -160,14 +160,10 @@ local function CrashRecovery(settings)
 		_undoTempSaveState = {
 			id = memorysavestate.savecorestate(),
 			timestamp = os.time(),
-			-- playtime = Tracker.Data.playtime
 		}
 		-- Then restore the game to the last known crash recovery save state
 		---@diagnostic disable-next-line: undefined-global
 		savestate.load(filepath, false) -- false: will show the on-screen display message
-
-		-- Once loaded, store a second copy of the backed up save in the Time Machine
-		-- TimeMachineScreen.createRestorePoint()
 	end
 
 	function self.undoRecoverSave()
@@ -175,7 +171,6 @@ local function CrashRecovery(settings)
 			return
 		end
 		memorysavestate.loadcorestate(_undoTempSaveState.id)
-		-- Tracker.Data.playtime = restorePoint.playtime
 		_undoTempSaveState = nil
 	end
 

--- a/ironmon_tracker/extras/CrashRecovery.lua
+++ b/ironmon_tracker/extras/CrashRecovery.lua
@@ -1,0 +1,232 @@
+local function CrashRecovery(settings)
+	local self = {}
+
+	-- INTERNAL VARS
+	local _crashReportFormat = "crashedOccurred:%s|gameName:%s|romHash:%s"
+	local _crashReportPattern = "crashedOccurred:([^|]*)|gameName:([^|]*)|romHash:([^|]*)"
+	local _crashReportFile = Paths.CURRENT_DIRECTORY .. Paths.SLASH .. "ironmon_tracker" .. Paths.SLASH .. "crashreport.txt"
+	local _backupFolder = Paths.CURRENT_DIRECTORY .. Paths.SLASH .. "savedData" .. Paths.SLASH .. "crashRecovery" .. Paths.SLASH
+	local _backupFrequency = 300 -- number of seconds to wait between backing up a save-state (once every 5 minutes)
+	local _lastBackupTime = 0 -- record the time the last backup was made
+	local _hasStarted = false -- Started later, only after the player begins the game
+	local _undoTempSaveState = nil -- Once a save is recovered, this holds a save state at the point in time right before that
+	local _crashReport = {}
+
+	-- INTERNAL FUNCTIONS
+	local function tryAppendSlash(path)
+		if (path or "") == "" or path:find("[/\\]$") then
+			return path
+		end
+		return path .. Paths.SLASH
+	end
+	local function trimSlash(path)
+		if (path or "") == "" or not path:find("[/\\]$") then
+			return path
+		end
+		return path:sub(1, -2)
+	end
+	local function folderExists(path)
+		if path == nil or #path == 0 then return false end
+		path = tryAppendSlash(path)
+		-- A hacky yet simple way to check if a folder exists: try to rename it
+		-- The "code" return value only exists in Lua 5.2+, but not required to use here
+		local exists, err, code = os.rename(path, path)
+		-- Code 13 = Permission denied, but it exists
+		if exists or (not exists and code == 13) then
+			return true
+		end
+		return false
+	end
+	local function createFolder(path)
+		if path == nil or #path == 0 then return end
+		path = trimSlash(path)
+		local command
+		if Paths.SLASH == "\\" then -- Windows
+			command = string.format('mkdir "%s"', path)
+		else -- Linux
+			command = string.format('mkdir -p "%s"', path)
+		end
+		os.execute(command)
+	end
+	local function getSaveStateFile()
+		return _backupFolder .. gameinfo.getromname() .. ".State"
+	end
+
+	-- EXTERNAL FUNCTIONS
+	function self.initialize()
+		-- Make sure the backup save folder exists before using it later
+		if not folderExists(_backupFolder) then
+			createFolder(_backupFolder)
+		end
+		_hasStarted = false
+		_lastBackupTime = os.time()
+		_undoTempSaveState = nil
+		_crashReport = {}
+	end
+
+	-- Crash Recovery will always record crash status, but if disabled it won't do anything with it
+	function self.isEnabled()
+		return settings.extras.RECOVERY_ENABLED ~= false -- Enabled if setting absent or set to true
+	end
+
+	function self.checkCrashStatus()
+		_crashReport = self.readCrashReport()
+
+		-- If no previous crash occurred, establish a new crash report; treat status as "crashed" until emulator safely exits
+		if not _crashReport.crashedOccurred then
+			self.writeCrashReport(true)
+		end
+
+		-- If a crash did occur for this same rom, inform the player and see if they want to recover
+		if self.isEnabled() and _crashReport.crashedOccurred and _crashReport.romHash == gameinfo.getromhash() then
+			self.openPromptCrashOccurred()
+		end
+	end
+
+	function self.getBackupFrequency()
+		return _backupFrequency
+	end
+
+	function self.startSavingBackups()
+		if not self.isEnabled() then return end
+		_hasStarted = true
+		_lastBackupTime = os.time()
+	end
+
+	function self.stopSavingBackups()
+		_hasStarted = false
+	end
+
+	function self.writeCrashReport(crashedOccurred)
+		if not self.isEnabled() then return end
+		local reportAsString = string.format(_crashReportFormat,
+			tostring(crashedOccurred == true),
+			gameinfo.getromname(),
+			gameinfo.getromhash()
+		)
+		MiscUtils.writeStringToFile(_crashReportFile, reportAsString)
+	end
+
+	function self.readCrashReport()
+		-- Default: no crash occurred
+		local crashReport = {
+			crashedOccurred = false,
+			gameName = gameinfo.getromname(),
+			romHash = gameinfo.getromhash(),
+		}
+		if not self.isEnabled() then
+			return crashReport
+		end
+
+		-- No crash occurred if the file doesn't exist or is empty (was never previously used)
+		local reportAsString = MiscUtils.readStringFromFile(_crashReportFile) or ""
+		if #reportAsString == 0 then
+			return crashReport
+		end
+
+		local crash, game, rom = reportAsString:match(_crashReportPattern)
+		crashReport.crashedOccurred = (crash == "true")
+		if (game or "") ~= "" then
+			crashReport.gameName = game
+		end
+		if (rom or "") ~= "" then
+			crashReport.romHash = rom
+		end
+		return crashReport
+	end
+
+	function self.createBackupSaveState()
+		if not _hasStarted then return end
+		local timeElapsed = os.time() - _lastBackupTime
+		if timeElapsed < _backupFrequency then
+			return
+		end
+		local filepath = getSaveStateFile()
+		if not folderExists(_backupFolder) then
+			return
+		end
+		---@diagnostic disable-next-line: undefined-global
+		savestate.save(filepath, true) -- true: suppresses the on-screen display message
+		_lastBackupTime = os.time()
+	end
+
+	function self.recoverSave()
+		local filepath = getSaveStateFile()
+		if not FormsUtils.fileExists(filepath) then
+			return
+		end
+
+		-- First create a temporary save state as a way to undo the recovery, if needed
+		_undoTempSaveState = {
+			id = memorysavestate.savecorestate(),
+			timestamp = os.time(),
+			-- playtime = Tracker.Data.playtime
+		}
+		-- Then restore the game to the last known crash recovery save state
+		---@diagnostic disable-next-line: undefined-global
+		savestate.load(filepath, false) -- false: will show the on-screen display message
+
+		-- Once loaded, store a second copy of the backed up save in the Time Machine
+		-- TimeMachineScreen.createRestorePoint()
+	end
+
+	function self.undoRecoverSave()
+		if type(_undoTempSaveState) ~= "table" or _undoTempSaveState.id == nil then
+			return
+		end
+		memorysavestate.loadcorestate(_undoTempSaveState.id)
+		-- Tracker.Data.playtime = restorePoint.playtime
+		_undoTempSaveState = nil
+	end
+
+	function self.openPromptCrashOccurred()
+		local form = forms.newform(350, 190, "Crash Detected!", function()
+			client.unpause()
+		end)
+		local clientCenter = FormsUtils.getCenter(350, 190)
+		forms.setlocation(form, clientCenter.xPos, clientCenter.yPos)
+
+		local x, y, lineHeight = 20, 20, 20
+		local lb1 = forms.label(form, "An emulator or game crash has been detected.", x, y)
+		y = y + lineHeight
+		local lb2 = forms.label(form, "The Tracker has a recovery save available prior to the crash.", x, y)
+		y = y + lineHeight
+		local lb3 = forms.label(form, "Load the recovery save?", x, y)
+		y = y + lineHeight
+		-- Bottom row buttons
+		y = y + 10
+		local btn1, btn2, btn3, btn4
+		btn1 = forms.button(form, "Yes (Recover)", function()
+			self.recoverSave()
+			forms.setproperty(btn3, "Enabled", true)
+		end, 21, y)
+		btn2 = forms.button(form, "No (Dismiss)", function()
+			forms.destroy(form)
+			client.unpause()
+		end, 130, y)
+		btn3 = forms.button(form, "Undo Recovery", function()
+			self.undoRecoverSave()
+			forms.setproperty(btn3, "Enabled", false)
+		end, 230, y)
+		y = y + lineHeight + 15
+		btn4 = forms.button(form, "Close / Cancel", function()
+			forms.destroy(form)
+			client.unpause()
+		end, 130, y)
+
+		-- Disable the "Undo" button by default
+		forms.setproperty(btn3, "Enabled", false)
+
+		-- Autosize form control elements
+		forms.setproperty(lb1, "AutoSize", true)
+		forms.setproperty(lb2, "AutoSize", true)
+		forms.setproperty(lb3, "AutoSize", true)
+		forms.setproperty(btn1, "AutoSize", true)
+		forms.setproperty(btn2, "AutoSize", true)
+		forms.setproperty(btn3, "AutoSize", true)
+		forms.setproperty(btn4, "AutoSize", true)
+	end
+
+	return self
+end
+return CrashRecovery


### PR DESCRIPTION
This PR (targeted to the `dev` branch) adds a new Crash Recovery feature to help recover game saves whenever an emulator crash occurs. This is done _not_ by saving information at the moment of the crash but rather by frequently creating a persistent backup save file. These save files are stored in the `/savedData/crashRecovery/` folder such that they are easy to locate.

This is a simple feature in concept yet I imagine it will be immensely helpful for several people, especially for people like me who forget to save their progress often. 

### Crash Recovery Feature Notes
- When a crash\* occurs, the Tracker will detect that it did not shut down properly. When it does, it will show a Crash Recovery popup when the Tracker starts up to let the player know a crash occurred, then ask if they want to try and recover the save.
- On the Crash Recovery popup, you can restore the game save automatically by using the last known automatic backup for a matching rom. Note: This "restore" loads a save state, and thus requires the user opened a proper matching rom.

\* The term "crash" here only applies when the emulator itself runs into an error that causes it to force quit, or it freezes, or there is a power outage. A "crash" won't occur if the player simply closes the emulator, or closes the lua console, or "Ends Process" through Task Manager.

Regardless of a crash occurring, the backup save files are always kept up to date, but the Tracker detecting the crash and prompting the player might not always occur. In other words, if someone accidentally dismisses the Crash prompt but still wants to recover their save, the file will remain in  `/savedData/crashRecovery/` until a new save state for that game is created to replace it.

### Example Screenshot In-Action
![image](https://github.com/user-attachments/assets/a562aaea-d205-429d-83e1-16b7b1c0174d)
